### PR TITLE
Implement finance domain store and services

### DIFF
--- a/src/services/data/finance.json
+++ b/src/services/data/finance.json
@@ -1,0 +1,9 @@
+{
+  "transactions": [],
+  "bills": [],
+  "preferences": {
+    "theme": "system"
+  },
+  "user": null,
+  "updatedAt": "2023-01-01T00:00:00.000Z"
+}

--- a/src/services/mockApi.ts
+++ b/src/services/mockApi.ts
@@ -1,0 +1,198 @@
+import dayjs from 'dayjs';
+import type {
+  Bill,
+  Preferences,
+  ThemePreference,
+  Transaction,
+  User,
+} from '../types/finance';
+import seedData from './data/finance.json';
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem?: (key: string) => void;
+};
+
+interface FinanceData {
+  transactions: Transaction[];
+  bills: Bill[];
+  preferences: Preferences;
+  user?: User;
+  updatedAt: string;
+}
+
+export type TransactionInput = Omit<Transaction, 'id' | 'createdAt' | 'updatedAt'> & {
+  id?: string;
+};
+
+export type BillInput = Omit<Bill, 'id' | 'paid' | 'paidAt'> & {
+  id?: string;
+  paid?: boolean;
+  paidAt?: string;
+};
+
+const STORAGE_KEY = 'codex-finance-data';
+const hasWindow = typeof window !== 'undefined';
+const storage: StorageLike | null = hasWindow && window.localStorage ? window.localStorage : null;
+
+const defaultData: FinanceData = {
+  transactions: (seedData.transactions ?? []) as Transaction[],
+  bills: (seedData.bills ?? []) as Bill[],
+  preferences: (seedData.preferences ?? { theme: 'system' }) as Preferences,
+  user: seedData.user === null ? undefined : (seedData.user as User | undefined),
+  updatedAt: seedData.updatedAt ?? dayjs().toISOString(),
+};
+
+let memoryStore: FinanceData | null = null;
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const ensureStore = (): FinanceData => {
+  if (memoryStore) {
+    return clone(memoryStore);
+  }
+
+  if (storage) {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as FinanceData;
+        memoryStore = parsed;
+        return clone(parsed);
+      } catch (error) {
+        console.warn('[mockApi] Could not parse storage data', error);
+      }
+    }
+  }
+
+  memoryStore = clone(defaultData);
+  return clone(memoryStore);
+};
+
+const persistStore = (data: FinanceData) => {
+  memoryStore = clone(data);
+  if (storage) {
+    storage.setItem(STORAGE_KEY, JSON.stringify(memoryStore));
+  }
+};
+
+const delay = (min = 120, max = 360) =>
+  new Promise((resolve) => setTimeout(resolve, Math.floor(Math.random() * (max - min + 1)) + min));
+
+const generateId = () =>
+  (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `id-${Math.random().toString(36).slice(2, 11)}-${Date.now()}`);
+
+const touchUpdatedAt = (data: FinanceData) => {
+  data.updatedAt = dayjs().toISOString();
+};
+
+export const listTransactions = async (): Promise<Transaction[]> => {
+  await delay();
+  const { transactions } = ensureStore();
+  return transactions
+    .slice()
+    .sort((a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf());
+};
+
+export const addTransaction = async (payload: TransactionInput): Promise<Transaction> => {
+  await delay();
+  const data = ensureStore();
+  const timestamp = dayjs().toISOString();
+  const transaction: Transaction = {
+    id: payload.id ?? generateId(),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...payload,
+  };
+  data.transactions = [transaction, ...data.transactions];
+  touchUpdatedAt(data);
+  persistStore(data);
+  return transaction;
+};
+
+export const listBills = async (): Promise<Bill[]> => {
+  await delay();
+  const { bills } = ensureStore();
+  return bills
+    .slice()
+    .sort((a, b) => dayjs(a.dueDate).valueOf() - dayjs(b.dueDate).valueOf());
+};
+
+export const addBill = async (payload: BillInput): Promise<Bill> => {
+  await delay();
+  const data = ensureStore();
+  const bill: Bill = {
+    id: payload.id ?? generateId(),
+    paid: payload.paid ?? false,
+    paidAt: payload.paidAt,
+    ...payload,
+  };
+  data.bills = [bill, ...data.bills];
+  touchUpdatedAt(data);
+  persistStore(data);
+  return bill;
+};
+
+export const markBillAsPaid = async (
+  id: string,
+  paidAt: string = dayjs().toISOString(),
+): Promise<Bill | undefined> => {
+  await delay();
+  const data = ensureStore();
+  const index = data.bills.findIndex((bill) => bill.id === id);
+  if (index === -1) {
+    return undefined;
+  }
+
+  const updated: Bill = {
+    ...data.bills[index],
+    paid: true,
+    paidAt,
+  };
+
+  data.bills[index] = updated;
+  touchUpdatedAt(data);
+  persistStore(data);
+  return updated;
+};
+
+export const getUser = async (): Promise<User | undefined> => {
+  await delay();
+  const { user } = ensureStore();
+  return user ? { ...user } : undefined;
+};
+
+export const updateUser = async (payload: User | ((current?: User) => User)): Promise<User> => {
+  await delay();
+  const data = ensureStore();
+  const nextUser = typeof payload === 'function' ? (payload as (current?: User) => User)(data.user) : payload;
+  data.user = { ...nextUser };
+  touchUpdatedAt(data);
+  persistStore(data);
+  return data.user;
+};
+
+export const getPreferences = async (): Promise<Preferences> => {
+  await delay();
+  const { preferences } = ensureStore();
+  return { ...preferences };
+};
+
+export const setThemePreference = async (theme: ThemePreference): Promise<Preferences> => {
+  await delay();
+  const data = ensureStore();
+  data.preferences = { ...data.preferences, theme };
+  touchUpdatedAt(data);
+  persistStore(data);
+  return { ...data.preferences };
+};
+
+export const resetMockData = async () => {
+  memoryStore = null;
+  if (storage && storage.removeItem) {
+    storage.removeItem(STORAGE_KEY);
+  }
+};

--- a/src/store/financeStore.ts
+++ b/src/store/financeStore.ts
@@ -1,0 +1,180 @@
+import dayjs from 'dayjs';
+import { create } from 'zustand';
+import type {
+  Bill,
+  Preferences,
+  ThemePreference,
+  Transaction,
+  User,
+} from '../types/finance';
+import * as api from '../services/mockApi';
+
+export interface FinanceStore {
+  transactions: Transaction[];
+  bills: Bill[];
+  preferences: Preferences;
+  user?: User;
+  loading: boolean;
+  error?: string;
+  lastSync?: string;
+  fetchTransactions: () => Promise<Transaction[]>;
+  addTransaction: (payload: api.TransactionInput) => Promise<Transaction>;
+  fetchBills: () => Promise<Bill[]>;
+  addBill: (payload: api.BillInput) => Promise<Bill>;
+  markBillAsPaid: (id: string, paidAt?: string) => Promise<Bill | undefined>;
+  fetchUser: () => Promise<User | undefined>;
+  saveUser: (payload: User | ((current?: User) => User)) => Promise<User>;
+  fetchPreferences: () => Promise<Preferences>;
+  setTheme: (theme: ThemePreference) => Promise<Preferences>;
+  clearError: () => void;
+}
+
+const mapError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === 'string' ? error : 'Ocorreu um erro inesperado.';
+};
+
+export const useFinanceStore = create<FinanceStore>((set, get) => ({
+  transactions: [],
+  bills: [],
+  preferences: { theme: 'system' },
+  user: undefined,
+  loading: false,
+  error: undefined,
+  lastSync: undefined,
+  async fetchTransactions() {
+    set({ loading: true, error: undefined });
+    try {
+      const transactions = await api.listTransactions();
+      set({
+        transactions,
+        loading: false,
+        lastSync: dayjs().toISOString(),
+      });
+      return transactions;
+    } catch (error) {
+      set({ loading: false, error: mapError(error) });
+      throw error;
+    }
+  },
+  async addTransaction(payload) {
+    try {
+      const transaction = await api.addTransaction(payload);
+      set((state) => ({
+        transactions: [transaction, ...state.transactions.filter((item) => item.id !== transaction.id)],
+        lastSync: dayjs().toISOString(),
+      }));
+      return transaction;
+    } catch (error) {
+      set({ error: mapError(error) });
+      throw error;
+    }
+  },
+  async fetchBills() {
+    set({ loading: true, error: undefined });
+    try {
+      const bills = await api.listBills();
+      set({
+        bills,
+        loading: false,
+        lastSync: dayjs().toISOString(),
+      });
+      return bills;
+    } catch (error) {
+      set({ loading: false, error: mapError(error) });
+      throw error;
+    }
+  },
+  async addBill(payload) {
+    try {
+      const bill = await api.addBill(payload);
+      set((state) => ({
+        bills: [bill, ...state.bills.filter((item) => item.id !== bill.id)],
+        lastSync: dayjs().toISOString(),
+      }));
+      return bill;
+    } catch (error) {
+      set({ error: mapError(error) });
+      throw error;
+    }
+  },
+  async markBillAsPaid(id, paidAt) {
+    try {
+      const updated = await api.markBillAsPaid(id, paidAt);
+      if (!updated) {
+        return undefined;
+      }
+      set((state) => ({
+        bills: state.bills.map((bill) => (bill.id === updated.id ? updated : bill)),
+        lastSync: dayjs().toISOString(),
+      }));
+      return updated;
+    } catch (error) {
+      set({ error: mapError(error) });
+      throw error;
+    }
+  },
+  async fetchUser() {
+    set({ loading: true, error: undefined });
+    try {
+      const user = await api.getUser();
+      set({
+        user,
+        loading: false,
+        lastSync: dayjs().toISOString(),
+      });
+      return user;
+    } catch (error) {
+      set({ loading: false, error: mapError(error) });
+      throw error;
+    }
+  },
+  async saveUser(payload) {
+    try {
+      const user = await api.updateUser(payload);
+      set({
+        user,
+        lastSync: dayjs().toISOString(),
+      });
+      return user;
+    } catch (error) {
+      set({ error: mapError(error) });
+      throw error;
+    }
+  },
+  async fetchPreferences() {
+    set({ loading: true, error: undefined });
+    try {
+      const preferences = await api.getPreferences();
+      set({
+        preferences,
+        loading: false,
+        lastSync: dayjs().toISOString(),
+      });
+      return preferences;
+    } catch (error) {
+      set({ loading: false, error: mapError(error) });
+      throw error;
+    }
+  },
+  async setTheme(theme) {
+    try {
+      const preferences = await api.setThemePreference(theme);
+      set({
+        preferences,
+        lastSync: dayjs().toISOString(),
+      });
+      return preferences;
+    } catch (error) {
+      set({ error: mapError(error) });
+      throw error;
+    }
+  },
+  clearError() {
+    if (get().error) {
+      set({ error: undefined });
+    }
+  },
+}));

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -1,0 +1,46 @@
+export type TransactionType = 'income' | 'expense';
+
+export interface Transaction {
+  id: string;
+  description: string;
+  amount: number;
+  category: string;
+  date: string;
+  type: TransactionType;
+  createdAt: string;
+  updatedAt: string;
+  notes?: string;
+}
+
+export interface Bill {
+  id: string;
+  name: string;
+  amount: number;
+  dueDate: string;
+  paid: boolean;
+  paidAt?: string;
+  notes?: string;
+  transactionId?: string;
+}
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+export interface Preferences {
+  theme: ThemePreference;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  themePreference?: ThemePreference;
+}
+
+export interface FinanceSnapshot {
+  transactions: Transaction[];
+  bills: Bill[];
+  preferences: Preferences;
+  user?: User;
+  updatedAt: string;
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,54 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/pt-br';
+
+dayjs.extend(relativeTime);
+dayjs.locale('pt-br');
+
+export const formatCurrencyBRL = (value: number, options?: Intl.NumberFormatOptions) =>
+  new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    ...options,
+  }).format(value);
+
+export const formatDate = (
+  value: string | Date,
+  pattern = 'DD/MM/YYYY',
+  fallback = '--',
+) => {
+  const date = dayjs(value);
+  if (!date.isValid()) {
+    return fallback;
+  }
+  return date.format(pattern);
+};
+
+export const formatDateTime = (
+  value: string | Date,
+  pattern = 'DD/MM/YYYY HH:mm',
+  fallback = '--',
+) => {
+  const date = dayjs(value);
+  if (!date.isValid()) {
+    return fallback;
+  }
+  return date.format(pattern);
+};
+
+export const formatRelativeDate = (value: string | Date, fallback = '--') => {
+  const date = dayjs(value);
+  if (!date.isValid()) {
+    return fallback;
+  }
+  return date.fromNow();
+};
+
+export const parseISODate = (value: string | Date) => {
+  const date = dayjs(value);
+  return date.isValid() ? date.toISOString() : undefined;
+};
+
+export const getDayjs = () => dayjs;


### PR DESCRIPTION
## Summary
- define shared finance domain types for transactions, bills, preferences, and snapshot metadata
- add a mock API service backed by local storage/JSON for transactions, bills, users, and theme preferences
- implement a Zustand finance store and utility formatters leveraging Day.js with pt-br locale

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e05c58a400832ea4ede13cb2b51a3b