### PR TITLE
Replace transaction placeholders with functional pages

### DIFF
--- a/src/components/FinanceCalendar.tsx
+++ b/src/components/FinanceCalendar.tsx
@@ -13,7 +13,7 @@ export const FinanceCalendar = () => {
   const events = useMemo<EventInput[]>(
     () =>
       bills.map((bill) => {
-        const color = bill.status === 'paid' ? '#16a34a' : '#f97316';
+        const color = bill.status === 'paid' ? '#34d399' : '#f97316';
 
         return {
           id: bill.id,
@@ -29,9 +29,9 @@ export const FinanceCalendar = () => {
   );
 
   return (
-    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow">
-      <h2 className="text-lg font-semibold text-slate-700">Calendário de contas</h2>
-      <p className="mb-4 text-sm text-slate-500">
+    <div className="calendar-surface rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20 backdrop-blur">
+      <h2 className="text-lg font-semibold text-white">Calendário de contas</h2>
+      <p className="mb-4 text-sm text-white/60">
         Eventos são atualizados automaticamente conforme contas são pagas ou permanecem pendentes.
       </p>
       <FullCalendar

--- a/src/index.css
+++ b/src/index.css
@@ -162,3 +162,51 @@ body {
  dev
  dev
 }
+
+.calendar-surface .fc-theme-standard td,
+.calendar-surface .fc-theme-standard th,
+.calendar-surface .fc-theme-standard .fc-scrollgrid {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.calendar-surface .fc .fc-toolbar-title,
+.calendar-surface .fc .fc-col-header-cell-cushion,
+.calendar-surface .fc .fc-daygrid-day-number {
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.calendar-surface .fc .fc-daygrid-day-frame {
+  background-color: transparent;
+}
+
+.calendar-surface .fc .fc-daygrid-day.fc-day-today {
+  background-color: rgba(138, 43, 226, 0.18);
+}
+
+.calendar-surface .fc .fc-button {
+  background-color: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: rgba(248, 250, 252, 0.92);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.calendar-surface .fc .fc-button:hover {
+  background-color: rgba(0, 234, 255, 0.2);
+  border-color: rgba(0, 234, 255, 0.35);
+}
+
+.calendar-surface .fc .fc-button:focus {
+  box-shadow: 0 0 0 2px rgba(0, 234, 255, 0.25);
+}
+
+.calendar-surface .fc .fc-button:disabled {
+  opacity: 0.5;
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.calendar-surface .fc .fc-daygrid-event {
+  border-radius: 0.75rem;
+  padding: 0.35rem 0.5rem;
+  font-weight: 600;
+}

--- a/src/pages/Bills/index.tsx
+++ b/src/pages/Bills/index.tsx
@@ -10,7 +10,7 @@ interface FeedbackMessage {
   message: string;
 }
 
-export default function Bills() {
+export function ContasAPagarPage() {
   const { bills, markBillPaid, payingBills } = useFinance();
   const [feedback, setFeedback] = useState<FeedbackMessage | null>(null);
 
@@ -38,88 +38,90 @@ export default function Bills() {
     }
   };
 
-  const sortedBills = [...bills].sort((first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf());
+  const sortedBills = [...bills].sort(
+    (first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf()
+  );
 
   return (
-    <main className="min-h-screen bg-slate-50 px-6 py-10">
-      <div className="mx-auto flex max-w-5xl flex-col gap-8">
-        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-slate-800">Contas a pagar</h1>
-              <p className="text-sm text-slate-600">
-                Acompanhe vencimentos, marque contas como pagas e gere a transação correspondente automaticamente.
-              </p>
-            </div>
-            <span className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-600">
-              {sortedBills.filter((bill) => bill.status === 'pending').length} pendentes
-            </span>
+    <section className="space-y-8">
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20 backdrop-blur">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-3xl font-semibold">Contas a pagar</h2>
+            <p className="text-sm text-white/70">
+              Acompanhe vencimentos, marque contas como pagas e gere a transação correspondente automaticamente.
+            </p>
           </div>
-
-          <div className="mt-6 overflow-x-auto">
-            <table className="min-w-full divide-y divide-slate-200 text-sm">
-              <thead className="bg-slate-100 text-left font-medium text-slate-600">
-                <tr>
-                  <th className="px-4 py-3">Descrição</th>
-                  <th className="px-4 py-3">Valor (BRL)</th>
-                  <th className="px-4 py-3">Vencimento</th>
-                  <th className="px-4 py-3">Status</th>
-                  <th className="px-4 py-3 text-right">Ações</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100 bg-white">
-                {sortedBills.map((bill) => {
-                  const isPaying = payingBills.includes(bill.id);
-
-                  return (
-                    <tr key={bill.id} className="transition hover:bg-slate-50">
-                      <td className="whitespace-nowrap px-4 py-3 font-medium text-slate-700">{bill.description}</td>
-                      <td className="whitespace-nowrap px-4 py-3 text-slate-600">{formatCurrency(bill.amountInCents)}</td>
-                      <td className="whitespace-nowrap px-4 py-3 text-slate-600">{formatDate(bill.dueDate)}</td>
-                      <td className="px-4 py-3">
-                        <span
-                          className={clsx(
-                            'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold',
-                            bill.status === 'paid'
-                              ? 'bg-emerald-50 text-emerald-600'
-                              : 'bg-amber-50 text-amber-600'
-                          )}
-                        >
-                          {bill.status === 'paid' ? 'Paga' : 'Pendente'}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <button
-                          className="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:border-emerald-300 hover:text-emerald-600 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-                          onClick={() => handleMarkPaid(bill.id)}
-                          disabled={bill.status === 'paid' || isPaying}
-                        >
-                          {isPaying ? 'Processando...' : 'Marcar como paga'}
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-
-          {feedback && (
-            <div
-              className={clsx(
-                'mt-4 rounded-md px-4 py-3 text-sm',
-                feedback.type === 'success'
-                  ? 'bg-emerald-50 text-emerald-700'
-                  : 'bg-rose-50 text-rose-600'
-              )}
-            >
-              {feedback.message}
-            </div>
-          )}
+          <span className="inline-flex items-center rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/70">
+            {sortedBills.filter((bill) => bill.status === 'pending').length} pendentes
+          </span>
         </div>
 
-        <FinanceCalendar />
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-white/10 text-sm">
+            <thead className="bg-white/10 text-left text-white/70">
+              <tr>
+                <th className="px-4 py-3 font-medium">Descrição</th>
+                <th className="px-4 py-3 font-medium">Valor (BRL)</th>
+                <th className="px-4 py-3 font-medium">Vencimento</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 text-right font-medium">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {sortedBills.map((bill) => {
+                const isPaying = payingBills.includes(bill.id);
+
+                return (
+                  <tr key={bill.id} className="transition hover:bg-white/5">
+                    <td className="whitespace-nowrap px-4 py-3 font-medium text-white">{bill.description}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-white/70">{formatCurrency(bill.amountInCents)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-white/70">{formatDate(bill.dueDate)}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={clsx(
+                          'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold',
+                          bill.status === 'paid'
+                            ? 'bg-emerald-500/10 text-emerald-300'
+                            : 'bg-amber-500/10 text-amber-300'
+                        )}
+                      >
+                        {bill.status === 'paid' ? 'Paga' : 'Pendente'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        className="inline-flex items-center justify-center rounded-lg border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:border-aurora-start hover:text-aurora-start disabled:cursor-not-allowed disabled:border-white/5 disabled:text-white/40"
+                        onClick={() => handleMarkPaid(bill.id)}
+                        disabled={bill.status === 'paid' || isPaying}
+                      >
+                        {isPaying ? 'Processando...' : 'Marcar como paga'}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {feedback && (
+          <div
+            className={clsx(
+              'mt-6 rounded-xl px-4 py-3 text-sm',
+              feedback.type === 'success'
+                ? 'bg-emerald-500/10 text-emerald-200'
+                : 'bg-rose-500/10 text-rose-200'
+            )}
+          >
+            {feedback.message}
+          </div>
+        )}
       </div>
-    </main>
+
+      <FinanceCalendar />
+    </section>
   );
 }
+
+export default ContasAPagarPage;

--- a/src/pages/ContasAPagar.tsx
+++ b/src/pages/ContasAPagar.tsx
@@ -1,15 +1,1 @@
-export function ContasAPagarPage() {
-  return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-semibold">Contas a pagar</h2>
-      <p className="text-sm text-white/70">
-        Organize compromissos e evite atrasos nos pagamentos.
-      </p>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-        <p className="text-white/80">
-          Cadastre fornecedores, datas de vencimento e status das faturas.
-        </p>
-      </div>
-    </section>
-  );
-}
+export { ContasAPagarPage } from './Bills';

--- a/src/pages/Entrada.tsx
+++ b/src/pages/Entrada.tsx
@@ -1,15 +1,1 @@
-export function EntradaPage() {
-  return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-semibold">Entradas</h2>
-      <p className="text-sm text-white/70">
-        Cadastre e acompanhe as entradas financeiras do período.
-      </p>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-        <p className="text-white/80">
-          Esta seção exibirá tabelas e gráficos sobre as receitas recebidas.
-        </p>
-      </div>
-    </section>
-  );
-}
+export { EntradaPage } from './Entrada';

--- a/src/pages/Entrada/index.tsx
+++ b/src/pages/Entrada/index.tsx
@@ -20,7 +20,11 @@ const createDefaultState = (): FormState => ({
   account: ''
 });
 
-export default function Entrada() {
+const inputClassName =
+  'mt-2 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 shadow-sm transition focus:border-aurora-start focus:outline-none focus:ring-2 focus:ring-aurora-start/40';
+const labelClassName = 'flex flex-col text-sm font-medium text-white/80';
+
+export function EntradaPage() {
   const { addTransaction, savingTransactionKind } = useFinance();
   const [formState, setFormState] = useState<FormState>(() => createDefaultState());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -89,106 +93,111 @@ export default function Entrada() {
   };
 
   return (
-    <main className="min-h-screen bg-slate-50 px-6 py-10">
-      <div className="mx-auto max-w-2xl">
-        <h1 className="text-2xl font-semibold text-slate-800">Registrar entrada</h1>
-        <p className="mt-1 text-sm text-slate-600">
-          Cadastre receitas informando a categoria, valor em centavos, data, descrição e conta de destino.
+    <section className="space-y-8">
+      <div className="space-y-2">
+        <h2 className="text-3xl font-semibold">Registrar entrada</h2>
+        <p className="text-sm text-white/70">
+          Cadastre receitas informando categoria, valor, data, descrição e conta responsável.
         </p>
+      </div>
 
-        <form onSubmit={handleSubmit} className="mt-8 space-y-6 rounded-lg bg-white p-6 shadow">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Categoria
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                name="category"
-                value={formState.category}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, category: event.target.value }))
-                }
-                placeholder="Ex.: Vendas"
-                list="income-categories"
-              />
-              <datalist id="income-categories">
-                {categories.map((category) => (
-                  <option key={category} value={category} />
-                ))}
-              </datalist>
-            </label>
-
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Valor (centavos)
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                name="amountInCents"
-                value={formState.amountInCents}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, amountInCents: event.target.value }))
-                }
-                type="number"
-                min={0}
-                step={1}
-                placeholder="10000"
-              />
-            </label>
-
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Data
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                name="date"
-                value={formState.date}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, date: event.target.value }))
-                }
-                type="date"
-              />
-            </label>
-
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Conta
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-                name="account"
-                value={formState.account}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, account: event.target.value }))
-                }
-                placeholder="Conta corrente"
-              />
-            </label>
-          </div>
-
-          <label className="flex flex-col text-sm font-medium text-slate-700">
-            Descrição
-            <textarea
-              className="mt-1 min-h-[96px] rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
-              name="description"
-              value={formState.description}
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20 backdrop-blur"
+      >
+        <div className="grid gap-6 md:grid-cols-2">
+          <label className={labelClassName}>
+            Categoria
+            <input
+              className={inputClassName}
+              name="category"
+              value={formState.category}
               onChange={(event) =>
-                setFormState((current) => ({ ...current, description: event.target.value }))
+                setFormState((current) => ({ ...current, category: event.target.value }))
               }
-              placeholder="Detalhes adicionais"
+              placeholder="Ex.: Vendas"
+              list="income-categories"
+            />
+            <datalist id="income-categories">
+              {categories.map((category) => (
+                <option key={category} value={category} />
+              ))}
+            </datalist>
+          </label>
+
+          <label className={labelClassName}>
+            Valor (centavos)
+            <input
+              className={inputClassName}
+              name="amountInCents"
+              value={formState.amountInCents}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, amountInCents: event.target.value }))
+              }
+              type="number"
+              min={0}
+              step={1}
+              placeholder="10000"
             />
           </label>
 
-          {amountPreview && (
-            <p className="text-sm text-slate-500">Valor equivalente: {amountPreview}</p>
-          )}
+          <label className={labelClassName}>
+            Data
+            <input
+              className={inputClassName}
+              name="date"
+              value={formState.date}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, date: event.target.value }))
+              }
+              type="date"
+            />
+          </label>
 
-          {errorMessage && <p className="text-sm text-rose-600">{errorMessage}</p>}
-          {successMessage && <p className="text-sm text-emerald-600">{successMessage}</p>}
+          <label className={labelClassName}>
+            Conta
+            <input
+              className={inputClassName}
+              name="account"
+              value={formState.account}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, account: event.target.value }))
+              }
+              placeholder="Conta corrente"
+            />
+          </label>
+        </div>
 
-          <button
-            className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-emerald-300"
-            type="submit"
-            disabled={isSubmitting}
-          >
-            {isSubmitting ? 'Salvando...' : 'Registrar entrada'}
-          </button>
-        </form>
-      </div>
-    </main>
+        <label className={labelClassName}>
+          Descrição
+          <textarea
+            className={`${inputClassName} min-h-[96px] resize-y`}
+            name="description"
+            value={formState.description}
+            onChange={(event) =>
+              setFormState((current) => ({ ...current, description: event.target.value }))
+            }
+            placeholder="Detalhes adicionais"
+          />
+        </label>
+
+        {amountPreview && (
+          <p className="text-sm text-white/60">Valor equivalente: {amountPreview}</p>
+        )}
+
+        {errorMessage && <p className="text-sm text-rose-300">{errorMessage}</p>}
+        {successMessage && <p className="text-sm text-emerald-300">{successMessage}</p>}
+
+        <button
+          className="inline-flex items-center justify-center rounded-xl bg-aurora-gradient px-5 py-2 text-sm font-semibold text-midnight shadow-lg shadow-aurora-end/30 transition hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-aurora-start/60 disabled:cursor-not-allowed disabled:opacity-60"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Salvando...' : 'Registrar entrada'}
+        </button>
+      </form>
+    </section>
   );
 }
+
+export default EntradaPage;

--- a/src/pages/Saida.tsx
+++ b/src/pages/Saida.tsx
@@ -1,15 +1,1 @@
-export function SaidaPage() {
-  return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-semibold">Saídas</h2>
-      <p className="text-sm text-white/70">
-        Controle as despesas registradas e mantenha a saúde financeira em dia.
-      </p>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-        <p className="text-white/80">
-          Lista de despesas, filtros e categorias aparecerão aqui.
-        </p>
-      </div>
-    </section>
-  );
-}
+export { SaidaPage } from './Saida';

--- a/src/pages/Saida/index.tsx
+++ b/src/pages/Saida/index.tsx
@@ -23,7 +23,11 @@ const createDefaultState = (): FormState => ({
   billId: ''
 });
 
-export default function Saida() {
+const inputClassName =
+  'mt-2 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 shadow-sm transition focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40';
+const labelClassName = 'flex flex-col text-sm font-medium text-white/80';
+
+export function SaidaPage() {
   const { addTransaction, bills, savingTransactionKind } = useFinance();
   const [formState, setFormState] = useState<FormState>(() => createDefaultState());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -92,125 +96,130 @@ export default function Saida() {
   const pendingBills = bills.filter((bill) => bill.status === 'pending');
 
   return (
-    <main className="min-h-screen bg-slate-50 px-6 py-10">
-      <div className="mx-auto max-w-2xl">
-        <h1 className="text-2xl font-semibold text-slate-800">Registrar saída</h1>
-        <p className="mt-1 text-sm text-slate-600">
+    <section className="space-y-8">
+      <div className="space-y-2">
+        <h2 className="text-3xl font-semibold">Registrar saída</h2>
+        <p className="text-sm text-white/70">
           Cadastre despesas e associe-as a contas pendentes para manter o controle em dia.
         </p>
+      </div>
 
-        <form onSubmit={handleSubmit} className="mt-8 space-y-6 rounded-lg bg-white p-6 shadow">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Categoria
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                name="category"
-                value={formState.category}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, category: event.target.value }))
-                }
-                placeholder="Ex.: Operacional"
-                list="expense-categories"
-              />
-              <datalist id="expense-categories">
-                {categories.map((category) => (
-                  <option key={category} value={category} />
-                ))}
-              </datalist>
-            </label>
-
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Valor (centavos)
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                name="amountInCents"
-                value={formState.amountInCents}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, amountInCents: event.target.value }))
-                }
-                type="number"
-                min={0}
-                step={1}
-                placeholder="8000"
-              />
-            </label>
-
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Data
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                name="date"
-                value={formState.date}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, date: event.target.value }))
-                }
-                type="date"
-              />
-            </label>
-
-            <label className="flex flex-col text-sm font-medium text-slate-700">
-              Conta
-              <input
-                className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
-                name="account"
-                value={formState.account}
-                onChange={(event) =>
-                  setFormState((current) => ({ ...current, account: event.target.value }))
-                }
-                placeholder="Conta corrente"
-              />
-            </label>
-          </div>
-
-          <label className="flex flex-col text-sm font-medium text-slate-700">
-            Associar conta a pagar (opcional)
-            <select
-              className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
-              name="billId"
-              value={formState.billId}
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20 backdrop-blur"
+      >
+        <div className="grid gap-6 md:grid-cols-2">
+          <label className={labelClassName}>
+            Categoria
+            <input
+              className={inputClassName}
+              name="category"
+              value={formState.category}
               onChange={(event) =>
-                setFormState((current) => ({ ...current, billId: event.target.value }))
+                setFormState((current) => ({ ...current, category: event.target.value }))
               }
-            >
-              <option value="">Sem associação</option>
-              {pendingBills.map((bill) => (
-                <option key={bill.id} value={bill.id}>
-                  {bill.description} — {formatCurrency(bill.amountInCents)} (vence em {dayjs(bill.dueDate).format('DD/MM')})
-                </option>
+              placeholder="Ex.: Operacional"
+              list="expense-categories"
+            />
+            <datalist id="expense-categories">
+              {categories.map((category) => (
+                <option key={category} value={category} />
               ))}
-            </select>
+            </datalist>
           </label>
 
-          <label className="flex flex-col text-sm font-medium text-slate-700">
-            Descrição
-            <textarea
-              className="mt-1 min-h-[96px] rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-rose-500 focus:outline-none focus:ring-2 focus:ring-rose-200"
-              name="description"
-              value={formState.description}
+          <label className={labelClassName}>
+            Valor (centavos)
+            <input
+              className={inputClassName}
+              name="amountInCents"
+              value={formState.amountInCents}
               onChange={(event) =>
-                setFormState((current) => ({ ...current, description: event.target.value }))
+                setFormState((current) => ({ ...current, amountInCents: event.target.value }))
               }
-              placeholder="Detalhes adicionais"
+              type="number"
+              min={0}
+              step={1}
+              placeholder="8000"
             />
           </label>
 
-          {amountPreview && (
-            <p className="text-sm text-slate-500">Valor equivalente: {amountPreview}</p>
-          )}
+          <label className={labelClassName}>
+            Data
+            <input
+              className={inputClassName}
+              name="date"
+              value={formState.date}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, date: event.target.value }))
+              }
+              type="date"
+            />
+          </label>
 
-          {errorMessage && <p className="text-sm text-rose-600">{errorMessage}</p>}
-          {successMessage && <p className="text-sm text-emerald-600">{successMessage}</p>}
+          <label className={labelClassName}>
+            Conta
+            <input
+              className={inputClassName}
+              name="account"
+              value={formState.account}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, account: event.target.value }))
+              }
+              placeholder="Conta corrente"
+            />
+          </label>
+        </div>
 
-          <button
-            className="inline-flex items-center justify-center rounded-md bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-rose-500 disabled:cursor-not-allowed disabled:bg-rose-300"
-            type="submit"
-            disabled={isSubmitting}
+        <label className={labelClassName}>
+          Associar conta a pagar (opcional)
+          <select
+            className={`${inputClassName} appearance-none`}
+            name="billId"
+            value={formState.billId}
+            onChange={(event) =>
+              setFormState((current) => ({ ...current, billId: event.target.value }))
+            }
           >
-            {isSubmitting ? 'Salvando...' : 'Registrar saída'}
-          </button>
-        </form>
-      </div>
-    </main>
+            <option value="">Sem associação</option>
+            {pendingBills.map((bill) => (
+              <option key={bill.id} value={bill.id}>
+                {bill.description} — {formatCurrency(bill.amountInCents)} (vence em {dayjs(bill.dueDate).format('DD/MM')})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={labelClassName}>
+          Descrição
+          <textarea
+            className={`${inputClassName} min-h-[96px] resize-y`}
+            name="description"
+            value={formState.description}
+            onChange={(event) =>
+              setFormState((current) => ({ ...current, description: event.target.value }))
+            }
+            placeholder="Detalhes adicionais"
+          />
+        </label>
+
+        {amountPreview && (
+          <p className="text-sm text-white/60">Valor equivalente: {amountPreview}</p>
+        )}
+
+        {errorMessage && <p className="text-sm text-rose-300">{errorMessage}</p>}
+        {successMessage && <p className="text-sm text-emerald-300">{successMessage}</p>}
+
+        <button
+          className="inline-flex items-center justify-center rounded-xl bg-aurora-gradient px-5 py-2 text-sm font-semibold text-midnight shadow-lg shadow-aurora-end/30 transition hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-aurora-start/60 disabled:cursor-not-allowed disabled:opacity-60"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Salvando...' : 'Registrar saída'}
+        </button>
+      </form>
+    </section>
   );
 }
+
+export default SaidaPage;


### PR DESCRIPTION
## Summary
- replace the Entrada and Saída placeholders with the stored-backed transaction forms from their feature folders and update their styling for the dark dashboard
- hook the Contas a Pagar route into the Bills screen, keeping the mark-as-paid flow and refreshing the table aesthetics
- tune the shared finance calendar with dark theme overrides so it blends with the layout

## Testing
- npm run build *(fails: repository package.json is corrupted and cannot be parsed)*

------
https://chatgpt.com/codex/tasks/task_b_68e11bf9f280832eb74674c0cb8b3505