### PR TITLE
feat: align finance types with mock API

### DIFF
--- a/src/components/FinanceCalendar.tsx
+++ b/src/components/FinanceCalendar.tsx
@@ -17,7 +17,7 @@ export const FinanceCalendar = () => {
 
         return {
           id: bill.id,
-          title: `${bill.description} • ${formatCurrency(bill.amountInCents)}`,
+          title: `${bill.description} • ${formatCurrency(bill.value)}`,
           start: bill.dueDate,
           allDay: true,
           backgroundColor: color,

--- a/src/pages/Bills/index.tsx
+++ b/src/pages/Bills/index.tsx
@@ -23,7 +23,7 @@ export default function Bills() {
       if (transaction) {
         setFeedback({
           type: 'success',
-          message: `Conta paga e transação de saída criada (${formatCurrency(transaction.amountInCents)}).`
+          message: `Conta paga e transação de saída criada (${formatCurrency(transaction.value)}).`
         });
       } else {
         setFeedback({ type: 'success', message: 'Conta já estava marcada como paga.' });
@@ -74,7 +74,7 @@ export default function Bills() {
                   return (
                     <tr key={bill.id} className="transition hover:bg-slate-50">
                       <td className="whitespace-nowrap px-4 py-3 font-medium text-slate-700">{bill.description}</td>
-                      <td className="whitespace-nowrap px-4 py-3 text-slate-600">{formatCurrency(bill.amountInCents)}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-slate-600">{formatCurrency(bill.value)}</td>
                       <td className="whitespace-nowrap px-4 py-3 text-slate-600">{formatDate(bill.dueDate)}</td>
                       <td className="px-4 py-3">
                         <span

--- a/src/pages/Entrada/index.tsx
+++ b/src/pages/Entrada/index.tsx
@@ -21,12 +21,12 @@ const createDefaultState = (): FormState => ({
 });
 
 export default function Entrada() {
-  const { addTransaction, savingTransactionKind } = useFinance();
+  const { addTransaction, savingTransactionType } = useFinance();
   const [formState, setFormState] = useState<FormState>(() => createDefaultState());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const isSubmitting = savingTransactionKind === 'entrada';
+  const isSubmitting = savingTransactionType === 'income';
 
   const amountPreview = useMemo(() => {
     if (!formState.amountInCents) {
@@ -68,9 +68,9 @@ export default function Entrada() {
     }
 
     try {
-      await addTransaction('entrada', {
+      await addTransaction('income', {
         category: formState.category.trim(),
-        amountInCents: Math.round(amount),
+        value: Math.round(amount),
         date: formState.date,
         description: formState.description.trim(),
         account: formState.account.trim()

--- a/src/pages/Saida/index.tsx
+++ b/src/pages/Saida/index.tsx
@@ -24,12 +24,12 @@ const createDefaultState = (): FormState => ({
 });
 
 export default function Saida() {
-  const { addTransaction, bills, savingTransactionKind } = useFinance();
+  const { addTransaction, bills, savingTransactionType } = useFinance();
   const [formState, setFormState] = useState<FormState>(() => createDefaultState());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const isSubmitting = savingTransactionKind === 'saida';
+  const isSubmitting = savingTransactionType === 'expense';
 
   const amountPreview = useMemo(() => {
     if (!formState.amountInCents) {
@@ -68,9 +68,9 @@ export default function Saida() {
     }
 
     try {
-      await addTransaction('saida', {
+      await addTransaction('expense', {
         category: formState.category.trim(),
-        amountInCents: Math.round(amount),
+        value: Math.round(amount),
         date: formState.date,
         description: formState.description.trim(),
         account: formState.account.trim(),
@@ -176,7 +176,7 @@ export default function Saida() {
               <option value="">Sem associação</option>
               {pendingBills.map((bill) => (
                 <option key={bill.id} value={bill.id}>
-                  {bill.description} — {formatCurrency(bill.amountInCents)} (vence em {dayjs(bill.dueDate).format('DD/MM')})
+                  {bill.description} — {formatCurrency(bill.value)} (vence em {dayjs(bill.dueDate).format('DD/MM')})
                 </option>
               ))}
             </select>

--- a/src/store/financeStore.ts
+++ b/src/store/financeStore.ts
@@ -2,9 +2,11 @@ import dayjs from 'dayjs';
 import { create } from 'zustand';
 import type {
   Bill,
+  BillInput,
   Preferences,
   ThemePreference,
   Transaction,
+  TransactionInput,
   User,
 } from '../types/finance';
 import * as api from '../services/mockApi';
@@ -18,9 +20,9 @@ export interface FinanceStore {
   error?: string;
   lastSync?: string;
   fetchTransactions: () => Promise<Transaction[]>;
-  addTransaction: (payload: api.TransactionInput) => Promise<Transaction>;
+  addTransaction: (payload: TransactionInput) => Promise<Transaction>;
   fetchBills: () => Promise<Bill[]>;
-  addBill: (payload: api.BillInput) => Promise<Bill>;
+  addBill: (payload: BillInput) => Promise<Bill>;
   markBillAsPaid: (id: string, paidAt?: string) => Promise<Bill | undefined>;
   fetchUser: () => Promise<User | undefined>;
   saveUser: (payload: User | ((current?: User) => User)) => Promise<User>;

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -1,55 +1,49 @@
- codex/create-page-components-for-transactions
-export type TransactionKind = 'entrada' | 'saida';
-
-export interface TransactionFormInput {
-  category: string;
-  amountInCents: number;
-  date: string;
-  description: string;
-  account: string;
-  billId?: string;
-}
-
-export interface Transaction extends TransactionFormInput {
-  id: string;
-  kind: TransactionKind;
-  createdAt: string;
-}
-
-export type BillStatus = 'pending' | 'paid';
-
-export interface Bill {
-  id: string;
-  description: string;
-  amountInCents: number;
-  dueDate: string;
-  status: BillStatus;
-  account: string;
-
 export type TransactionType = 'income' | 'expense';
 
-export interface Transaction {
-  id: string;
-  description: string;
-  amount: number;
+export interface TransactionDraft {
   category: string;
+  description: string;
+  account: string;
   date: string;
+  value: number;
+  billId?: string;
+  notes?: string;
+}
+
+export interface Transaction extends TransactionDraft {
+  id: string;
+  userId: string;
   type: TransactionType;
   createdAt: string;
   updatedAt: string;
-  notes?: string;
 }
 
-export interface Bill {
-  id: string;
-  name: string;
-  amount: number;
+export type TransactionInput = TransactionDraft &
+  Pick<Transaction, 'userId' | 'type'> &
+  Partial<Pick<Transaction, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type BillStatus = 'pending' | 'paid';
+
+export interface BillDraft {
+  description: string;
+  account: string;
+  value: number;
   dueDate: string;
-  paid: boolean;
-  paidAt?: string;
+  userId: string;
   notes?: string;
   transactionId?: string;
 }
+
+export interface Bill extends BillDraft {
+  id: string;
+  status: BillStatus;
+  createdAt: string;
+  updatedAt: string;
+  paidAt?: string;
+}
+
+export type BillInput = BillDraft &
+  Partial<Pick<Bill, 'id' | 'status' | 'createdAt' | 'updatedAt' | 'paidAt'>>;
 
 export type ThemePreference = 'light' | 'dark' | 'system';
 
@@ -61,6 +55,8 @@ export interface User {
   id: string;
   name: string;
   email: string;
+  createdAt: string;
+  updatedAt: string;
   avatarUrl?: string;
   themePreference?: ThemePreference;
 }
@@ -71,5 +67,4 @@ export interface FinanceSnapshot {
   preferences: Preferences;
   user?: User;
   updatedAt: string;
- dev
 }


### PR DESCRIPTION
## Summary
- replace the finance type definitions with normalized transaction, bill, and user models including userId fields and cent-based values
- export shared TransactionInput/BillInput helpers and refactor the mock API plus stores to consume the new shapes
- update FinanceContext and UI flows to rely on the new transaction type strings and value fields

## Testing
- npx tsc --noEmit *(fails: tsconfig.json is corrupted in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68e1212d57a8832eac35310f61105c55