### PR TITLE
Add transaction forms and sync bills with calendar

### DIFF
--- a/src/components/FinanceCalendar.tsx
+++ b/src/components/FinanceCalendar.tsx
@@ -4,11 +4,11 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import type { EventInput } from '@fullcalendar/core';
 import ptLocale from '@fullcalendar/core/locales/pt-br';
-import { useFinance } from '../store/FinanceContext';
+import { useFinanceStore } from '../store/financeStore';
 import { formatCurrency } from '../utils/format';
 
 export const FinanceCalendar = () => {
-  const { bills } = useFinance();
+  const bills = useFinanceStore((state) => state.bills);
 
   const events = useMemo<EventInput[]>(
     () =>

--- a/src/pages/ContasAPagar.tsx
+++ b/src/pages/ContasAPagar.tsx
@@ -1,15 +1,161 @@
+import { useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import dayjs from 'dayjs';
+import { useFinanceStore } from '../store/financeStore';
+import { FinanceCalendar } from '../components/FinanceCalendar';
+import { formatCurrency } from '../utils/format';
+
+interface FeedbackMessage {
+  type: 'success' | 'error';
+  message: string;
+}
+
 export function ContasAPagarPage() {
+  const bills = useFinanceStore((state) => state.bills);
+  const fetchBills = useFinanceStore((state) => state.fetchBills);
+  const markBillAsPaid = useFinanceStore((state) => state.markBillAsPaid);
+  const payingBillIds = useFinanceStore((state) => state.payingBillIds);
+  const loading = useFinanceStore((state) => state.loading);
+
+  const [feedback, setFeedback] = useState<FeedbackMessage | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!hasLoaded) {
+      fetchBills()
+        .catch(() => {
+          setFeedback({ type: 'error', message: 'Não foi possível carregar as contas.' });
+        })
+        .finally(() => setHasLoaded(true));
+    }
+  }, [fetchBills, hasLoaded]);
+
+  const sortedBills = useMemo(
+    () =>
+      [...bills].sort(
+        (first, second) => dayjs(first.dueDate).valueOf() - dayjs(second.dueDate).valueOf(),
+      ),
+    [bills],
+  );
+
+  const pendingCount = sortedBills.filter((bill) => bill.status === 'pending').length;
+
+  const handleMarkPaid = async (billId: string) => {
+    setFeedback(null);
+
+    try {
+      const { transaction } = await markBillAsPaid(billId);
+
+      if (transaction) {
+        setFeedback({
+          type: 'success',
+          message: `Conta paga e transação criada (${formatCurrency(transaction.amountInCents)}).`,
+        });
+      } else {
+        setFeedback({ type: 'success', message: 'Conta já estava marcada como paga.' });
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        setFeedback({ type: 'error', message: error.message });
+        return;
+      }
+
+      setFeedback({ type: 'error', message: 'Não foi possível atualizar a conta.' });
+    }
+  };
+
   return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-semibold">Contas a pagar</h2>
-      <p className="text-sm text-white/70">
-        Organize compromissos e evite atrasos nos pagamentos.
-      </p>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-        <p className="text-white/80">
-          Cadastre fornecedores, datas de vencimento e status das faturas.
-        </p>
+    <section className="space-y-8">
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/20">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-3xl font-semibold text-white">Contas a pagar</h2>
+            <p className="text-sm text-white/70">
+              Organize compromissos, marque pagamentos e acompanhe o status das faturas.
+            </p>
+          </div>
+          <span className="inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/80">
+            {pendingCount} pendentes
+          </span>
+        </div>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-white/10 text-sm">
+            <thead className="bg-white/5 text-left font-medium text-white/70">
+              <tr>
+                <th className="px-4 py-3">Descrição</th>
+                <th className="px-4 py-3">Valor (BRL)</th>
+                <th className="px-4 py-3">Vencimento</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3 text-right">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {sortedBills.map((bill) => {
+                const isPaying = payingBillIds.includes(bill.id);
+
+                return (
+                  <tr key={bill.id} className="transition hover:bg-white/5">
+                    <td className="whitespace-nowrap px-4 py-3 font-medium text-white">
+                      {bill.description}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-white/80">
+                      {formatCurrency(bill.amountInCents)}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-white/80">
+                      {dayjs(bill.dueDate).format('DD/MM/YYYY')}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={clsx(
+                          'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold',
+                          bill.status === 'paid'
+                            ? 'bg-emerald-500/20 text-emerald-300'
+                            : 'bg-amber-500/20 text-amber-200',
+                        )}
+                      >
+                        {bill.status === 'paid' ? 'Paga' : 'Pendente'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        className="inline-flex items-center justify-center rounded-md border border-white/20 bg-white/5 px-3 py-1.5 text-xs font-medium text-white transition hover:border-emerald-300 hover:text-emerald-200 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-white/40"
+                        onClick={() => handleMarkPaid(bill.id)}
+                        disabled={bill.status === 'paid' || isPaying}
+                      >
+                        {isPaying ? 'Processando...' : 'Marcar pago'}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {feedback && (
+          <div
+            className={clsx(
+              'mt-4 rounded-md px-4 py-3 text-sm',
+              feedback.type === 'success'
+                ? 'bg-emerald-500/20 text-emerald-200'
+                : 'bg-rose-500/20 text-rose-200',
+            )}
+          >
+            {feedback.message}
+          </div>
+        )}
+
+        {loading && !hasLoaded && (
+          <p className="mt-4 text-sm text-white/60">Carregando contas...</p>
+        )}
+
+        {!loading && hasLoaded && sortedBills.length === 0 && (
+          <p className="mt-4 text-sm text-white/60">Nenhuma conta cadastrada ainda.</p>
+        )}
       </div>
+
+      <FinanceCalendar />
     </section>
   );
 }

--- a/src/pages/Entrada.tsx
+++ b/src/pages/Entrada.tsx
@@ -1,15 +1,210 @@
+import { FormEvent, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import { useFinanceStore } from '../store/financeStore';
+
+interface FormState {
+  category: string;
+  amountInCents: string;
+  date: string;
+  description: string;
+  account: string;
+}
+
+const categories = ['Vendas', 'Investimentos', 'Reembolsos', 'Outros'];
+
+const createDefaultState = (): FormState => ({
+  category: '',
+  amountInCents: '',
+  date: dayjs().format('YYYY-MM-DD'),
+  description: '',
+  account: '',
+});
+
 export function EntradaPage() {
+  const createTransaction = useFinanceStore((state) => state.createTransaction);
+  const creatingTransactionKind = useFinanceStore((state) => state.creatingTransactionKind);
+  const storeError = useFinanceStore((state) => state.error);
+  const clearError = useFinanceStore((state) => state.clearError);
+
+  const [formState, setFormState] = useState<FormState>(() => createDefaultState());
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const isSubmitting = creatingTransactionKind === 'entrada';
+
+  const amountPreview = useMemo(() => {
+    if (!formState.amountInCents) {
+      return null;
+    }
+
+    const parsed = Number(formState.amountInCents);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return null;
+    }
+
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(parsed / 100);
+  }, [formState.amountInCents]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSuccessMessage(null);
+    setLocalError(null);
+    if (storeError) {
+      clearError();
+    }
+
+    const amount = Number(formState.amountInCents);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setLocalError('Informe um valor válido em centavos.');
+      return;
+    }
+
+    if (!formState.category.trim()) {
+      setLocalError('Selecione ou informe uma categoria.');
+      return;
+    }
+
+    if (!formState.account.trim()) {
+      setLocalError('Informe a conta responsável.');
+      return;
+    }
+
+    try {
+      await createTransaction({
+        kind: 'entrada',
+        category: formState.category.trim(),
+        amountInCents: Math.round(amount),
+        date: formState.date,
+        description: formState.description.trim(),
+        account: formState.account.trim(),
+      });
+
+      setFormState(createDefaultState());
+      setSuccessMessage('Entrada registrada com sucesso!');
+    } catch (error) {
+      if (error instanceof Error) {
+        setLocalError(error.message);
+        return;
+      }
+
+      setLocalError('Não foi possível salvar a entrada.');
+    }
+  };
+
   return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-semibold">Entradas</h2>
-      <p className="text-sm text-white/70">
-        Cadastre e acompanhe as entradas financeiras do período.
-      </p>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-        <p className="text-white/80">
-          Esta seção exibirá tabelas e gráficos sobre as receitas recebidas.
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-semibold">Entradas</h2>
+        <p className="text-sm text-white/70">
+          Cadastre e acompanhe as entradas financeiras do período.
         </p>
       </div>
+
+      <form
+        className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/20"
+        onSubmit={handleSubmit}
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Categoria
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              name="category"
+              value={formState.category}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, category: event.target.value }))
+              }
+              placeholder="Ex.: Vendas"
+              list="entrada-categories"
+              required
+            />
+            <datalist id="entrada-categories">
+              {categories.map((category) => (
+                <option key={category} value={category} />
+              ))}
+            </datalist>
+          </label>
+
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Valor (centavos)
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              name="amountInCents"
+              value={formState.amountInCents}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, amountInCents: event.target.value }))
+              }
+              type="number"
+              min={0}
+              step={1}
+              placeholder="10000"
+              required
+            />
+          </label>
+
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Data
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              name="date"
+              value={formState.date}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, date: event.target.value }))
+              }
+              type="date"
+              max={dayjs().format('YYYY-MM-DD')}
+              required
+            />
+          </label>
+
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Conta
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+              name="account"
+              value={formState.account}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, account: event.target.value }))
+              }
+              placeholder="Conta corrente"
+              required
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col text-sm font-medium text-white/80">
+          Descrição
+          <textarea
+            className="mt-1 min-h-[96px] rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+            name="description"
+            value={formState.description}
+            onChange={(event) =>
+              setFormState((current) => ({ ...current, description: event.target.value }))
+            }
+            placeholder="Detalhes adicionais"
+          />
+        </label>
+
+        {amountPreview && (
+          <p className="text-sm text-emerald-300/80">Valor equivalente: {amountPreview}</p>
+        )}
+
+        {(localError || storeError) && (
+          <p className="text-sm text-rose-300">
+            {localError ?? storeError}
+          </p>
+        )}
+
+        {successMessage && <p className="text-sm text-emerald-300">{successMessage}</p>}
+
+        <button
+          className="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-700/60"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Salvando...' : 'Registrar entrada'}
+        </button>
+      </form>
     </section>
   );
 }

--- a/src/pages/Saida.tsx
+++ b/src/pages/Saida.tsx
@@ -1,15 +1,287 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import { useFinanceStore } from '../store/financeStore';
+import { formatCurrency } from '../utils/format';
+
+interface FormState {
+  category: string;
+  amountInCents: string;
+  date: string;
+  description: string;
+  account: string;
+  billId?: string;
+}
+
+const categories = ['Operacional', 'Investimentos', 'Folha de pagamento', 'Impostos'];
+
+const createDefaultState = (): FormState => ({
+  category: '',
+  amountInCents: '',
+  date: dayjs().format('YYYY-MM-DD'),
+  description: '',
+  account: '',
+  billId: undefined,
+});
+
 export function SaidaPage() {
+  const createTransaction = useFinanceStore((state) => state.createTransaction);
+  const creatingTransactionKind = useFinanceStore((state) => state.creatingTransactionKind);
+  const bills = useFinanceStore((state) => state.bills);
+  const fetchBills = useFinanceStore((state) => state.fetchBills);
+  const storeError = useFinanceStore((state) => state.error);
+  const clearError = useFinanceStore((state) => state.clearError);
+
+  const [formState, setFormState] = useState<FormState>(() => createDefaultState());
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [hasLoadedBills, setHasLoadedBills] = useState(false);
+
+  useEffect(() => {
+    if (!hasLoadedBills) {
+      fetchBills()
+        .catch(() => {
+          setLocalError('Não foi possível carregar as contas a pagar.');
+        })
+        .finally(() => setHasLoadedBills(true));
+    }
+  }, [fetchBills, hasLoadedBills]);
+
+  const isSubmitting = creatingTransactionKind === 'saida';
+
+  const pendingBills = useMemo(
+    () => bills.filter((bill) => bill.status === 'pending'),
+    [bills],
+  );
+
+  const amountPreview = useMemo(() => {
+    if (!formState.amountInCents) {
+      return null;
+    }
+
+    const parsed = Number(formState.amountInCents);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return null;
+    }
+
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(parsed / 100);
+  }, [formState.amountInCents]);
+
+  const handleBillSelection = (billId: string | undefined) => {
+    if (!billId) {
+      setFormState((current) => ({ ...current, billId: undefined }));
+      return;
+    }
+
+    const selected = pendingBills.find((bill) => bill.id === billId);
+    if (!selected) {
+      setFormState((current) => ({ ...current, billId: undefined }));
+      return;
+    }
+
+    setFormState({
+      category: 'Pagamento de conta',
+      amountInCents: String(selected.amountInCents),
+      date: dayjs().format('YYYY-MM-DD'),
+      description: `Pagamento de ${selected.description}`,
+      account: selected.account,
+      billId: selected.id,
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSuccessMessage(null);
+    setLocalError(null);
+    if (storeError) {
+      clearError();
+    }
+
+    const amount = Number(formState.amountInCents);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setLocalError('Informe um valor válido em centavos.');
+      return;
+    }
+
+    if (!formState.category.trim()) {
+      setLocalError('Selecione ou informe uma categoria.');
+      return;
+    }
+
+    if (!formState.account.trim()) {
+      setLocalError('Informe a conta responsável.');
+      return;
+    }
+
+    try {
+      await createTransaction({
+        kind: 'saida',
+        category: formState.category.trim(),
+        amountInCents: Math.round(amount),
+        date: formState.date,
+        description: formState.description.trim(),
+        account: formState.account.trim(),
+        billId: formState.billId,
+      });
+
+      setFormState(createDefaultState());
+      setSuccessMessage('Saída registrada com sucesso!');
+    } catch (error) {
+      if (error instanceof Error) {
+        setLocalError(error.message);
+        return;
+      }
+
+      setLocalError('Não foi possível salvar a saída.');
+    }
+  };
+
   return (
-    <section className="space-y-4">
-      <h2 className="text-2xl font-semibold">Saídas</h2>
-      <p className="text-sm text-white/70">
-        Controle as despesas registradas e mantenha a saúde financeira em dia.
-      </p>
-      <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-        <p className="text-white/80">
-          Lista de despesas, filtros e categorias aparecerão aqui.
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-semibold">Saídas</h2>
+        <p className="text-sm text-white/70">
+          Controle as despesas registradas e mantenha a saúde financeira em dia.
         </p>
       </div>
+
+      <form
+        className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/20"
+        onSubmit={handleSubmit}
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Categoria
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40"
+              name="category"
+              value={formState.category}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, category: event.target.value }))
+              }
+              placeholder="Ex.: Operacional"
+              list="saida-categories"
+              required
+            />
+            <datalist id="saida-categories">
+              {categories.map((category) => (
+                <option key={category} value={category} />
+              ))}
+            </datalist>
+          </label>
+
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Valor (centavos)
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40"
+              name="amountInCents"
+              value={formState.amountInCents}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, amountInCents: event.target.value }))
+              }
+              type="number"
+              min={0}
+              step={1}
+              placeholder="5000"
+              required
+            />
+          </label>
+
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Data
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40"
+              name="date"
+              value={formState.date}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, date: event.target.value }))
+              }
+              type="date"
+              max={dayjs().format('YYYY-MM-DD')}
+              required
+            />
+          </label>
+
+          <label className="flex flex-col text-sm font-medium text-white/80">
+            Conta
+            <input
+              className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40"
+              name="account"
+              value={formState.account}
+              onChange={(event) =>
+                setFormState((current) => ({ ...current, account: event.target.value }))
+              }
+              placeholder="Conta corrente"
+              required
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col text-sm font-medium text-white/80">
+          Descrição
+          <textarea
+            className="mt-1 min-h-[96px] rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40"
+            name="description"
+            value={formState.description}
+            onChange={(event) =>
+              setFormState((current) => ({ ...current, description: event.target.value }))
+            }
+            placeholder="Detalhes da despesa"
+          />
+        </label>
+
+        <label className="flex flex-col text-sm font-medium text-white/80">
+          Vincular a uma conta a pagar (opcional)
+          <select
+            className="mt-1 rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white focus:border-rose-400 focus:outline-none focus:ring-2 focus:ring-rose-400/40"
+            value={formState.billId ?? ''}
+            onChange={(event) => handleBillSelection(event.target.value || undefined)}
+          >
+            <option value="">Não vincular</option>
+            {pendingBills.map((bill) => (
+              <option key={bill.id} value={bill.id}>
+                {bill.description} • {formatCurrency(bill.amountInCents)} • vence {dayjs(bill.dueDate).format('DD/MM')}
+              </option>
+            ))}
+          </select>
+          {formState.billId && (
+            <span className="mt-1 text-xs text-white/60">
+              Valores e descrição foram preenchidos com base na conta selecionada.
+            </span>
+          )}
+        </label>
+
+        {amountPreview && (
+          <p className="text-sm text-rose-200/80">Valor equivalente: {amountPreview}</p>
+        )}
+
+        {(localError || storeError) && (
+          <p className="text-sm text-rose-300">{localError ?? storeError}</p>
+        )}
+
+        {successMessage && <p className="text-sm text-emerald-300">{successMessage}</p>}
+
+        <button
+          className="inline-flex items-center justify-center rounded-xl bg-rose-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-rose-400 disabled:cursor-not-allowed disabled:bg-rose-700/60"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Salvando...' : 'Registrar saída'}
+        </button>
+      </form>
+
+      {pendingBills.length > 0 && (
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+          <h3 className="text-base font-semibold text-white">Contas pendentes</h3>
+          <ul className="mt-3 space-y-2">
+            {pendingBills.map((bill) => (
+              <li key={bill.id} className="flex flex-col rounded-xl bg-white/5 px-4 py-3">
+                <span className="font-medium text-white">{bill.description}</span>
+                <span>{formatCurrency(bill.amountInCents)} — vence em {dayjs(bill.dueDate).format('DD/MM/YYYY')}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/store/financeStore.ts
+++ b/src/store/financeStore.ts
@@ -5,6 +5,8 @@ import type {
   Preferences,
   ThemePreference,
   Transaction,
+  TransactionFormInput,
+  TransactionKind,
   User,
 } from '../types/finance';
 import * as api from '../services/mockApi';
@@ -17,11 +19,18 @@ export interface FinanceStore {
   loading: boolean;
   error?: string;
   lastSync?: string;
+  creatingTransactionKind: TransactionKind | null;
+  payingBillIds: string[];
   fetchTransactions: () => Promise<Transaction[]>;
-  addTransaction: (payload: api.TransactionInput) => Promise<Transaction>;
+  createTransaction: (
+    payload: TransactionFormInput & { kind: TransactionKind }
+  ) => Promise<Transaction>;
   fetchBills: () => Promise<Bill[]>;
   addBill: (payload: api.BillInput) => Promise<Bill>;
-  markBillAsPaid: (id: string, paidAt?: string) => Promise<Bill | undefined>;
+  markBillAsPaid: (
+    id: string,
+    paidAt?: string,
+  ) => Promise<{ bill?: Bill; transaction?: Transaction }>;
   fetchUser: () => Promise<User | undefined>;
   saveUser: (payload: User | ((current?: User) => User)) => Promise<User>;
   fetchPreferences: () => Promise<Preferences>;
@@ -44,6 +53,8 @@ export const useFinanceStore = create<FinanceStore>((set, get) => ({
   loading: false,
   error: undefined,
   lastSync: undefined,
+  creatingTransactionKind: null,
+  payingBillIds: [],
   async fetchTransactions() {
     set({ loading: true, error: undefined });
     try {
@@ -59,16 +70,39 @@ export const useFinanceStore = create<FinanceStore>((set, get) => ({
       throw error;
     }
   },
-  async addTransaction(payload) {
+  async createTransaction(payload) {
+    set({ creatingTransactionKind: payload.kind, error: undefined });
     try {
       const transaction = await api.addTransaction(payload);
-      set((state) => ({
-        transactions: [transaction, ...state.transactions.filter((item) => item.id !== transaction.id)],
-        lastSync: dayjs().toISOString(),
-      }));
+      set((state) => {
+        const transactions = [
+          transaction,
+          ...state.transactions.filter((item) => item.id !== transaction.id),
+        ].sort((first, second) => dayjs(second.date).valueOf() - dayjs(first.date).valueOf());
+
+        const bills = payload.billId
+          ? state.bills.map((bill) =>
+              bill.id === payload.billId
+                ? {
+                    ...bill,
+                    status: 'paid',
+                    paidAt: payload.date,
+                    transactionId: transaction.id,
+                  }
+                : bill,
+            )
+          : state.bills;
+
+        return {
+          transactions,
+          bills,
+          lastSync: dayjs().toISOString(),
+          creatingTransactionKind: null,
+        };
+      });
       return transaction;
     } catch (error) {
-      set({ error: mapError(error) });
+      set({ creatingTransactionKind: null, error: mapError(error) });
       throw error;
     }
   },
@@ -101,18 +135,62 @@ export const useFinanceStore = create<FinanceStore>((set, get) => ({
     }
   },
   async markBillAsPaid(id, paidAt) {
+    const { bills } = get();
+    const target = bills.find((bill) => bill.id === id);
+    if (!target) {
+      const error = new Error('Conta não encontrada.');
+      set({ error: error.message });
+      throw error;
+    }
+
+    if (target.status === 'paid') {
+      return { bill: target, transaction: undefined };
+    }
+
+    set((state) => ({
+      payingBillIds: state.payingBillIds.includes(id)
+        ? state.payingBillIds
+        : [...state.payingBillIds, id],
+      error: undefined,
+    }));
+
     try {
-      const updated = await api.markBillAsPaid(id, paidAt);
-      if (!updated) {
-        return undefined;
-      }
+      const paymentDate = paidAt ?? dayjs().format('YYYY-MM-DD');
+      const transaction = await api.addTransaction({
+        kind: 'saida',
+        category: 'Pagamento de conta',
+        amountInCents: target.amountInCents,
+        date: paymentDate,
+        description: `Pagamento de ${target.description}`,
+        account: target.account,
+        billId: target.id,
+      });
+
+      const updatedBill: Bill = {
+        ...target,
+        status: 'paid',
+        paidAt: paymentDate,
+        transactionId: transaction.id,
+      };
+
+      await api.markBillAsPaid(target.id, paymentDate, transaction.id);
+
       set((state) => ({
-        bills: state.bills.map((bill) => (bill.id === updated.id ? updated : bill)),
+        transactions: [
+          transaction,
+          ...state.transactions.filter((item) => item.id !== transaction.id),
+        ].sort((first, second) => dayjs(second.date).valueOf() - dayjs(first.date).valueOf()),
+        bills: state.bills.map((bill) => (bill.id === id ? updatedBill : bill)),
         lastSync: dayjs().toISOString(),
+        payingBillIds: state.payingBillIds.filter((billId) => billId !== id),
       }));
-      return updated;
+
+      return { bill: updatedBill, transaction };
     } catch (error) {
-      set({ error: mapError(error) });
+      set((state) => ({
+        payingBillIds: state.payingBillIds.filter((billId) => billId !== id),
+        error: mapError(error),
+      }));
       throw error;
     }
   },

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -1,4 +1,5 @@
- codex/create-page-components-for-transactions
+import type { TransactionInput as ApiTransactionInput, BillInput as ApiBillInput } from '../services/mockApi';
+
 export type TransactionKind = 'entrada' | 'saida';
 
 export interface TransactionFormInput {
@@ -14,6 +15,7 @@ export interface Transaction extends TransactionFormInput {
   id: string;
   kind: TransactionKind;
   createdAt: string;
+  updatedAt: string;
 }
 
 export type BillStatus = 'pending' | 'paid';
@@ -25,30 +27,9 @@ export interface Bill {
   dueDate: string;
   status: BillStatus;
   account: string;
-
-export type TransactionType = 'income' | 'expense';
-
-export interface Transaction {
-  id: string;
-  description: string;
-  amount: number;
-  category: string;
-  date: string;
-  type: TransactionType;
-  createdAt: string;
-  updatedAt: string;
-  notes?: string;
-}
-
-export interface Bill {
-  id: string;
-  name: string;
-  amount: number;
-  dueDate: string;
-  paid: boolean;
   paidAt?: string;
-  notes?: string;
   transactionId?: string;
+  notes?: string;
 }
 
 export type ThemePreference = 'light' | 'dark' | 'system';
@@ -71,5 +52,7 @@ export interface FinanceSnapshot {
   preferences: Preferences;
   user?: User;
   updatedAt: string;
- dev
 }
+
+export type TransactionInput = ApiTransactionInput;
+export type BillInput = ApiBillInput;


### PR DESCRIPTION
## Summary
- implement entrada and saída pages with validated forms that create transactions via the mock API store
- expand the Zustand finance store and mock API to handle bill linking, payment actions, and expose UI state
- render the contas a pagar table with mark-paid workflow and keep the calendar in sync with bill status

## Testing
- not run (package.json is currently invalid, preventing dependency installation)


------
https://chatgpt.com/codex/tasks/task_b_68e12130b010832eb9560cb79ccd4643