### PR TITLE
Refine finance data contracts and usage

### DIFF
--- a/src/pages/Entrada/index.tsx
+++ b/src/pages/Entrada/index.tsx
@@ -21,12 +21,12 @@ const createDefaultState = (): FormState => ({
 });
 
 export default function Entrada() {
-  const { addTransaction, savingTransactionKind } = useFinance();
+  const { addTransaction, savingTransactionType } = useFinance();
   const [formState, setFormState] = useState<FormState>(() => createDefaultState());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const isSubmitting = savingTransactionKind === 'entrada';
+  const isSubmitting = savingTransactionType === 'income';
 
   const amountPreview = useMemo(() => {
     if (!formState.amountInCents) {
@@ -68,7 +68,7 @@ export default function Entrada() {
     }
 
     try {
-      await addTransaction('entrada', {
+      await addTransaction('income', {
         category: formState.category.trim(),
         amountInCents: Math.round(amount),
         date: formState.date,

--- a/src/pages/Saida/index.tsx
+++ b/src/pages/Saida/index.tsx
@@ -24,12 +24,12 @@ const createDefaultState = (): FormState => ({
 });
 
 export default function Saida() {
-  const { addTransaction, bills, savingTransactionKind } = useFinance();
+  const { addTransaction, bills, savingTransactionType } = useFinance();
   const [formState, setFormState] = useState<FormState>(() => createDefaultState());
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const isSubmitting = savingTransactionKind === 'saida';
+  const isSubmitting = savingTransactionType === 'expense';
 
   const amountPreview = useMemo(() => {
     if (!formState.amountInCents) {
@@ -68,7 +68,7 @@ export default function Saida() {
     }
 
     try {
-      await addTransaction('saida', {
+      await addTransaction('expense', {
         category: formState.category.trim(),
         amountInCents: Math.round(amount),
         date: formState.date,

--- a/src/services/mockApi.ts
+++ b/src/services/mockApi.ts
@@ -26,10 +26,9 @@ export type TransactionInput = Omit<Transaction, 'id' | 'createdAt' | 'updatedAt
   id?: string;
 };
 
-export type BillInput = Omit<Bill, 'id' | 'paid' | 'paidAt'> & {
+export type BillInput = Omit<Bill, 'id' | 'status'> & {
   id?: string;
-  paid?: boolean;
-  paidAt?: string;
+  status?: Bill['status'];
 };
 
 const STORAGE_KEY = 'codex-finance-data';
@@ -126,9 +125,8 @@ export const addBill = async (payload: BillInput): Promise<Bill> => {
   const data = ensureStore();
   const bill: Bill = {
     id: payload.id ?? generateId(),
-    paid: payload.paid ?? false,
-    paidAt: payload.paidAt,
     ...payload,
+    status: payload.status ?? 'pending',
   };
   data.bills = [bill, ...data.bills];
   touchUpdatedAt(data);
@@ -149,7 +147,7 @@ export const markBillAsPaid = async (
 
   const updated: Bill = {
     ...data.bills[index],
-    paid: true,
+    status: 'paid',
     paidAt,
   };
 

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -1,56 +1,3 @@
- codex/create-page-components-for-transactions
-export type TransactionKind = 'entrada' | 'saida';
-
-export interface TransactionFormInput {
-  category: string;
-  amountInCents: number;
-  date: string;
-  description: string;
-  account: string;
-  billId?: string;
-}
-
-export interface Transaction extends TransactionFormInput {
-  id: string;
-  kind: TransactionKind;
-  createdAt: string;
-}
-
-export type BillStatus = 'pending' | 'paid';
-
-export interface Bill {
-  id: string;
-  description: string;
-  amountInCents: number;
-  dueDate: string;
-  status: BillStatus;
-  account: string;
-
-export type TransactionType = 'income' | 'expense';
-
-export interface Transaction {
-  id: string;
-  description: string;
-  amount: number;
-  category: string;
-  date: string;
-  type: TransactionType;
-  createdAt: string;
-  updatedAt: string;
-  notes?: string;
-}
-
-export interface Bill {
-  id: string;
-  name: string;
-  amount: number;
-  dueDate: string;
-  paid: boolean;
-  paidAt?: string;
-  notes?: string;
-  transactionId?: string;
-}
-
 export type ThemePreference = 'light' | 'dark' | 'system';
 
 export interface Preferences {
@@ -62,14 +9,35 @@ export interface User {
   name: string;
   email: string;
   avatarUrl?: string;
-  themePreference?: ThemePreference;
+  preferences?: Preferences;
 }
 
-export interface FinanceSnapshot {
-  transactions: Transaction[];
-  bills: Bill[];
-  preferences: Preferences;
-  user?: User;
-  updatedAt: string;
- dev
+export type TransactionType = 'income' | 'expense';
+
+export interface Transaction {
+  id: string;
+  type: TransactionType;
+  category: string;
+  amountInCents: number;
+  date: string;
+  description: string;
+  account: string;
+  createdAt: string;
+  updatedAt?: string;
+  billId?: string;
+  notes?: string;
+}
+
+export type BillStatus = 'pending' | 'paid';
+
+export interface Bill {
+  id: string;
+  description: string;
+  amountInCents: number;
+  dueDate: string;
+  status: BillStatus;
+  account: string;
+  paidAt?: string;
+  notes?: string;
+  transactionId?: string;
 }


### PR DESCRIPTION
## Summary
- replace the finance domain typings with clean user, transaction, bill, and preference interfaces using centavo amounts and ISO dates
- update the finance context and related forms to consume the new transaction type names and track associations to bills
- align the mock API helpers with the updated bill status model and transaction metadata

## Testing
- npm run build *(fails: package.json is not valid JSON in this workspace)*

------
https://chatgpt.com/codex/tasks/task_b_68e11bca9d4c832e90a7c43e78db97be