### PR TITLE
Update dashboard routing structure

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,13 +2,13 @@ import { NavLink } from 'react-router-dom';
 import clsx from 'classnames';
 
 const navItems = [
-  { to: '/', label: 'Dashboard' },
-  { to: '/entrada', label: 'Entrada' },
-  { to: '/saida', label: 'Saída' },
-  { to: '/contas-a-pagar', label: 'Contas a pagar' },
-  { to: '/grafico-pizza', label: 'Gráfico Pizza' },
-  { to: '/temas', label: 'Temas' },
-  { to: '/configuracoes', label: 'Configurações' }
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/dashboard/entrada', label: 'Entrada' },
+  { to: '/dashboard/saida', label: 'Saída' },
+  { to: '/dashboard/bills', label: 'Contas a pagar' },
+  { to: '/dashboard/pie', label: 'Gráfico Pizza' },
+  { to: '/dashboard/temas', label: 'Temas' },
+  { to: '/dashboard/configuracoes', label: 'Configurações' }
 ];
 
 export function Sidebar() {
@@ -26,7 +26,7 @@ export function Sidebar() {
           <NavLink
             key={item.to}
             to={item.to}
-            end={item.to === '/'}
+            end={item.to === '/dashboard'}
             className={({ isActive }) =>
               clsx(
                 'flex items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition',

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -2,13 +2,14 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { Sidebar } from '../components/Sidebar';
 
 const titles: Record<string, string> = {
-  '/': 'Dashboard',
-  '/entrada': 'Entradas',
-  '/saida': 'Saídas',
-  '/contas-a-pagar': 'Contas a pagar',
-  '/grafico-pizza': 'Gráfico Pizza',
-  '/temas': 'Temas',
-  '/configuracoes': 'Configurações'
+  '/dashboard': 'Dashboard',
+  '/dashboard/dashboard': 'Dashboard',
+  '/dashboard/entrada': 'Entradas',
+  '/dashboard/saida': 'Saídas',
+  '/dashboard/bills': 'Contas a pagar',
+  '/dashboard/pie': 'Gráfico Pizza',
+  '/dashboard/temas': 'Temas',
+  '/dashboard/configuracoes': 'Configurações'
 };
 
 export function DashboardLayout() {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -34,7 +34,7 @@ export function LoginPage() {
           </button>
         </form>
         <p className="text-xs text-white/60">
-          Ainda não possui conta? <Link to="/" className="text-aurora-start">Solicite acesso</Link>
+          Ainda não possui conta? <Link to="/dashboard" className="text-aurora-start">Solicite acesso</Link>
         </p>
       </div>
     </div>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,16 +17,25 @@ export const router = createBrowserRouter([
     element: <LoginPage />
   },
   {
+    path: '/dashboard',
     element: <DashboardLayout />,
     children: [
       { index: true, element: <DashboardPage /> },
+      { path: 'dashboard', element: <DashboardPage /> },
       { path: 'entrada', element: <EntradaPage /> },
       { path: 'saida', element: <SaidaPage /> },
-      { path: 'contas-a-pagar', element: <ContasAPagarPage /> },
-      { path: 'grafico-pizza', element: <GraficoPizzaPage /> },
+      { path: 'bills', element: <ContasAPagarPage /> },
+      { path: 'pie', element: <GraficoPizzaPage /> },
       { path: 'temas', element: <TemasPage /> },
-      { path: 'configuracoes', element: <ConfiguracoesPage /> },
-      { path: '*', element: <Navigate to="/" replace /> }
+      { path: 'configuracoes', element: <ConfiguracoesPage /> }
     ]
+  },
+  {
+    path: '/',
+    element: <Navigate to="/dashboard" replace />
+  },
+  {
+    path: '*',
+    element: <Navigate to="/dashboard" replace />
   }
 ]);


### PR DESCRIPTION
## Summary
- mount the dashboard layout at `/dashboard` with updated child routes using the new English path segments and redirect fallbacks
- refresh the sidebar navigation and login link to point at the new `/dashboard/*` paths while keeping Portuguese labels
- align the dashboard header titles with the relocated routes

## Testing
- npm run lint *(fails: Invalid package.json parse error)*

------
https://chatgpt.com/codex/tasks/task_b_68e1212eb35c832e8ce1662864bae496