### PR TITLE
Rebuild package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,112 +1,6 @@
 {
- codex/implement-usetheme-hook-and-context
-  "name": "codex-dashboard",
-  "private": true,
-  "version": "0.0.1",
-
- codex/create-page-components-for-transactions
-  "name": "codex-finance",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
-  },
-  "dependencies": {
-    "@fullcalendar/core": "^6.1.10",
-    "@fullcalendar/daygrid": "^6.1.10",
-    "@fullcalendar/interaction": "^6.1.10",
-    "@fullcalendar/react": "^6.1.10",
-    "clsx": "^1.2.1",
-    "dayjs": "^1.11.10",
-    "next": "^14.2.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
-    "@types/node": "^20.11.19",
-    "@types/react": "^18.2.21",
-    "@types/react-dom": "^18.2.7",
-    "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.31",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3"
-
- codex/create-kpi-cards-with-recharts
   "name": "codex-dashboard",
   "version": "0.1.0",
-  "private": true,
- dev
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "preview": "vite preview"
-  },
-  "dependencies": {
- codex/implement-usetheme-hook-and-context
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
-    "@types/react": "^18.2.18",
-    "@types/react-dom": "^18.2.7",
-    "@vitejs/plugin-react": "^4.0.3",
-    "autoprefixer": "^10.4.15",
-    "postcss": "^8.4.31",
-    "tailwindcss": "^3.3.3",
-    "typescript": "^5.2.2",
-    "vite": "^4.4.9"
-
-    "@fullcalendar/core": "6.1.15",
-    "@fullcalendar/daygrid": "6.1.15",
-    "@fullcalendar/interaction": "6.1.15",
-    "@fullcalendar/react": "6.1.15",
-    "@fullcalendar/timegrid": "6.1.15",
-    "clsx": "2.1.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "recharts": "2.12.7"
-  },
-  "devDependencies": {
-    "@types/react": "18.3.3",
-    "@types/react-dom": "18.3.0",
-    "@vitejs/plugin-react-swc": "3.7.1",
-    "autoprefixer": "10.4.19",
-    "postcss": "8.4.35",
-    "tailwindcss": "3.4.10",
-    "typescript": "5.4.5",
-    "vite": "5.2.12"
-
- codex/create-dashboardlayout-components-and-routing
-  "name": "codex-dashboard",
-  "private": true,
-  "version": "0.0.1",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "classnames": "^2.5.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.2"
-  },
-  "devDependencies": {
-    "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
-    "@vitejs/plugin-react": "^4.2.0",
-    "autoprefixer": "^10.4.16",
-    "postcss": "^8.4.31",
-    "tailwindcss": "^3.3.6",
-    "typescript": "^5.2.2",
-    "vite": "^5.0.0"
-
-  "name": "finance",
-  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -116,22 +10,28 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@fullcalendar/daygrid": "^6.1.11",
-    "@fullcalendar/interaction": "^6.1.11",
-    "@fullcalendar/react": "^6.1.11",
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.15",
+    "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "dayjs": "^1.11.11",
     "dayjs-plugin-utc": "^0.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
-    "recharts": "^2.10.3",
+    "recharts": "^2.12.7",
     "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
+    "@types/classnames": "^2.3.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react-swc": "^3.7.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react-swc": "^3.7.1",
     "autoprefixer": "^10.4.19",
     "eslint": "^9.4.0",
     "eslint-plugin-react": "^7.34.4",
@@ -141,10 +41,6 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.13.1",
-    "vite": "^5.2.11"
- dev
- dev
- dev
- dev
+    "vite": "^5.2.12"
   }
 }


### PR DESCRIPTION
## Summary
- replace the corrupted package.json with a clean manifest for the Vite + React + TypeScript app
- keep only the dependencies actually referenced in the codebase, including React Router, Zustand, Recharts, FullCalendar, Tailwind CSS, and Day.js
- add the dev, build, preview, and lint scripts expected for the project tooling

## Testing
- npm install *(fails: 403 Forbidden fetching @eslint/js from the registry)*

------
https://chatgpt.com/codex/tasks/task_b_68e1212bff0c832e9e355165f259effd