### PR TITLE
Add interactive chart components with usage guide

### DIFF
--- a/src/charts/DonutBreakdownChart.tsx
+++ b/src/charts/DonutBreakdownChart.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import type { CSSProperties } from 'react';
+import { Cell, Pie, PieChart, ResponsiveContainer, Sector, Tooltip } from 'recharts';
+
+export interface DonutSlice {
+  name: string;
+  value: number;
+  color?: string;
+}
+
+export interface DonutBreakdownChartProps {
+  title?: string;
+  caption?: string;
+  data: DonutSlice[];
+  /** Valor exibido no centro (por exemplo, total). */
+  centerLabel?: string;
+  /** Texto do rodapé explicativo. */
+  helperText?: string;
+  defaultColorPalette?: string[];
+}
+
+const tooltipStyles: CSSProperties = {
+  background: '#0f172a',
+  border: '1px solid rgba(148, 163, 184, 0.3)',
+  borderRadius: 12,
+  padding: '10px 12px',
+  color: '#f1f5f9',
+  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.35)'
+};
+
+export function DonutBreakdownChart({
+  title,
+  caption,
+  data,
+  centerLabel,
+  helperText,
+  defaultColorPalette = ['#ef4444', '#f97316', '#facc15', '#22d3ee', '#a855f7']
+}: DonutBreakdownChartProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  return (
+    <section className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20">
+      {(title || caption) && (
+        <header className="flex flex-wrap items-center gap-3">
+          {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}
+          {caption && (
+            <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/70">{caption}</span>
+          )}
+        </header>
+      )}
+      <div className="relative flex h-72 flex-col items-center justify-center">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              innerRadius={70}
+              outerRadius={110}
+              paddingAngle={4}
+              cornerRadius={18}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+              onMouseLeave={() => setActiveIndex(null)}
+              activeIndex={activeIndex ?? undefined}
+              activeShape={(props) => (
+                <Sector
+                  {...props}
+                  outerRadius={(props.outerRadius ?? 110) + 6}
+                  cornerRadius={18}
+                />
+              )}
+            >
+              {data.map((entry, index) => (
+                <Cell
+                  key={`slice-${entry.name}-${index}`}
+                  fill={entry.color ?? defaultColorPalette[index % defaultColorPalette.length]}
+                  stroke="rgba(15, 23, 42, 0.9)"
+                  strokeWidth={2}
+                />
+              ))}
+            </Pie>
+            <Tooltip
+              contentStyle={tooltipStyles}
+              formatter={(value: number, name: string) => [`${value}`, name]}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+        {centerLabel && (
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+            <p className="text-xs uppercase tracking-widest text-white/50">Total</p>
+            <p className="text-2xl font-semibold text-white">{centerLabel}</p>
+          </div>
+        )}
+      </div>
+      {helperText && <p className="text-sm text-white/60">{helperText}</p>}
+    </section>
+  );
+}

--- a/src/charts/InteractiveBarChart.tsx
+++ b/src/charts/InteractiveBarChart.tsx
@@ -1,0 +1,95 @@
+import type { CSSProperties } from 'react';
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+
+export interface InteractiveBarDatum {
+  label: string;
+  value: number;
+  color?: string;
+  [key: string]: string | number | undefined;
+}
+
+export interface InteractiveBarChartProps {
+  title?: string;
+  data: InteractiveBarDatum[];
+  /**
+   * Cor padrão (hex, rgb, hsl etc). Caso não seja informada, usamos um tom laranja semelhante ao layout base.
+   */
+  defaultColor?: string;
+  /**
+   * Personalize a cor da grade ou deixe `undefined` para usar o padrão suave.
+   */
+  gridColor?: string;
+  /**
+   * Texto opcional exibido ao lado do título (ex.: período).
+   */
+  caption?: string;
+}
+
+const tooltipStyles: CSSProperties = {
+  background: '#0f172a',
+  border: '1px solid rgba(148, 163, 184, 0.3)',
+  borderRadius: 12,
+  padding: '10px 12px',
+  color: '#f1f5f9',
+  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.35)'
+};
+
+export function InteractiveBarChart({
+  title,
+  data,
+  defaultColor = '#f97316',
+  gridColor = 'rgba(148, 163, 184, 0.16)',
+  caption
+}: InteractiveBarChartProps) {
+  return (
+    <section className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20">
+      {(title || caption) && (
+        <header className="flex flex-wrap items-center gap-3">
+          {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}
+          {caption && (
+            <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/70">{caption}</span>
+          )}
+        </header>
+      )}
+      <div className="h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <RechartsBarChart data={data} barSize={32}>
+            <CartesianGrid stroke={gridColor} strokeDasharray="3 12" vertical={false} />
+            <XAxis
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: '#cbd5f5', fontSize: 12 }}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: '#cbd5f5', fontSize: 12 }}
+              width={48}
+            />
+            <Tooltip
+              cursor={{ opacity: 0.12 }}
+              contentStyle={tooltipStyles}
+              formatter={(value: number) => [value, 'Valor']}
+              labelClassName="text-sm font-medium text-white"
+            />
+            <Bar dataKey="value" radius={[12, 12, 0, 0]}>
+              {data.map((entry, index) => (
+                <Cell key={`bar-${entry.label}-${index}`} fill={entry.color ?? defaultColor} />
+              ))}
+            </Bar>
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/charts/MultiSeriesLineChart.tsx
+++ b/src/charts/MultiSeriesLineChart.tsx
@@ -1,0 +1,92 @@
+import type { CSSProperties } from 'react';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart as RechartsLineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+
+export interface LineDescriptor {
+  dataKey: string;
+  name: string;
+  color: string;
+  /** controla o estilo do traçado ("solid", "dashed" etc). */
+  strokeDasharray?: string;
+}
+
+export interface MultiSeriesLineChartProps<T extends Record<string, unknown>> {
+  data: T[];
+  lines: LineDescriptor[];
+  xKey: keyof T & string;
+  title?: string;
+  caption?: string;
+  gridColor?: string;
+}
+
+const tooltipStyles: CSSProperties = {
+  background: '#0f172a',
+  border: '1px solid rgba(148, 163, 184, 0.3)',
+  borderRadius: 12,
+  padding: '10px 12px',
+  color: '#f8fafc',
+  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.35)'
+};
+
+export function MultiSeriesLineChart<T extends Record<string, unknown>>({
+  data,
+  lines,
+  xKey,
+  title,
+  caption,
+  gridColor = 'rgba(148, 163, 184, 0.16)'
+}: MultiSeriesLineChartProps<T>) {
+  return (
+    <section className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20">
+      {(title || caption) && (
+        <header className="flex flex-wrap items-center gap-3">
+          {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}
+          {caption && (
+            <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/70">{caption}</span>
+          )}
+        </header>
+      )}
+      <div className="h-72 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <RechartsLineChart data={data}>
+            <CartesianGrid stroke={gridColor} strokeDasharray="3 12" />
+            <XAxis dataKey={xKey} tickLine={false} axisLine={false} tick={{ fill: '#cbd5f5', fontSize: 12 }} />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: '#cbd5f5', fontSize: 12 }}
+              width={48}
+            />
+            <Tooltip contentStyle={tooltipStyles} cursor={{ strokeDasharray: '4 8', strokeWidth: 2 }} />
+            <Legend
+              wrapperStyle={{ color: '#f8fafc' }}
+              iconType="circle"
+              formatter={(value: string) => <span className="text-sm text-white/80">{value}</span>}
+            />
+            {lines.map((line) => (
+              <Line
+                key={line.dataKey}
+                type="monotone"
+                dataKey={line.dataKey}
+                name={line.name}
+                stroke={line.color}
+                strokeWidth={3}
+                strokeDasharray={line.strokeDasharray}
+                dot={{ r: 5, stroke: '#0f172a', strokeWidth: 2 }}
+                activeDot={{ r: 7 }}
+              />
+            ))}
+          </RechartsLineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/charts/README.md
+++ b/src/charts/README.md
@@ -1,0 +1,126 @@
+# Guia rápido dos gráficos interativos
+
+Este diretório reúne versões independentes dos quatro gráficos exibidos no mockup do dashboard. Todos eles utilizam [`recharts`](https://recharts.org/en-US/) e aceitam propriedades para personalização de cores, rótulos e legendas. Assim você pode usar cada componente separadamente em qualquer página da aplicação.
+
+## Como instalar dependências
+
+O projeto já possui o `recharts` listado no `package.json`. Caso ainda não tenha instalado as dependências, rode:
+
+```bash
+npm install
+```
+
+## Como utilizar cada componente
+
+Os exemplos abaixo consideram um arquivo React qualquer (por exemplo, `src/pages/Dashboard.tsx`). Basta importar o gráfico desejado e enviar os dados no formato indicado.
+
+### 1. Gráfico de colunas (`InteractiveBarChart`)
+```tsx
+import { InteractiveBarChart } from '@/charts';
+
+const barData = [
+  { label: 'Q1', value: 120, color: '#f97316' },
+  { label: 'Q2', value: 86, color: '#facc15' },
+  { label: 'Q3', value: 142, color: '#34d399' },
+  { label: 'Q4', value: 98, color: '#38bdf8' }
+];
+
+<InteractiveBarChart
+  title="Receita por trimestre"
+  caption="Ano 20XX"
+  data={barData}
+  defaultColor="#f97316"
+/>;
+```
+
+- `color` é opcional em cada item. Se não informar, o componente usará `defaultColor`.
+- Passe qualquer string CSS válida (`#hex`, `rgb()`, `hsl()`).
+
+### 2. Gráfico de linhas com múltiplas séries (`MultiSeriesLineChart`)
+```tsx
+import { MultiSeriesLineChart } from '@/charts';
+
+const lineData = [
+  { month: 'Jan', receita: 120, meta: 110, despesas: 70 },
+  { month: 'Fev', receita: 135, meta: 120, despesas: 82 },
+  // ...
+];
+
+<MultiSeriesLineChart
+  title="Evolução mensal"
+  caption="Últimos 6 meses"
+  data={lineData}
+  xKey="month"
+  lines={[
+    { dataKey: 'receita', name: 'Receita', color: '#f97316' },
+    { dataKey: 'meta', name: 'Meta', color: '#22d3ee', strokeDasharray: '6 4' },
+    { dataKey: 'despesas', name: 'Despesas', color: '#ef4444' }
+  ]}
+/>;
+```
+
+- Use quantas séries quiser. Cada item em `lines` define o rótulo da legenda e a cor correspondente.
+- `strokeDasharray` é opcional e aceita qualquer padrão SVG (ex.: `'6 4'`).
+
+### 3. Gráfico de rosca (`DonutBreakdownChart`)
+```tsx
+import { DonutBreakdownChart } from '@/charts';
+
+const donutData = [
+  { name: 'Marketing', value: 40, color: '#f97316' },
+  { name: 'Operações', value: 26, color: '#22d3ee' },
+  { name: 'Pessoal', value: 22, color: '#a855f7' },
+  { name: 'Outros', value: 12, color: '#facc15' }
+];
+
+<DonutBreakdownChart
+  title="Distribuição de custos"
+  caption="Trimestre atual"
+  data={donutData}
+  centerLabel="R$ 240k"
+  helperText="Passe o mouse para destacar cada categoria."
+/>;
+```
+
+- Se alguma fatia não tiver `color`, o componente utilizará a paleta padrão (`defaultColorPalette`).
+- O valor `centerLabel` fica fixo no centro da rosca.
+
+### 4. Mini gráfico de tendência (`SparklineTrendChart`)
+```tsx
+import { SparklineTrendChart } from '@/charts';
+
+const sparklineData = [
+  { label: 'S1', value: 20 },
+  { label: 'S2', value: 28 },
+  // ...
+];
+
+<SparklineTrendChart
+  title="Visitas"
+  caption="Últimas 8 semanas"
+  data={sparklineData}
+  lineColor="#34d399"
+/>;
+```
+
+- Use `lineColor` e `areaColor` para personalizar tanto a linha quanto o gradiente.
+
+## Organização do código
+
+Criamos um arquivo de índice para facilitar os imports:
+
+```ts
+// src/charts/index.ts
+export * from './InteractiveBarChart';
+export * from './MultiSeriesLineChart';
+export * from './DonutBreakdownChart';
+export * from './SparklineTrendChart';
+```
+
+Ao importar usando `@/charts`, verifique se o alias `@` já aponta para a pasta `src` no seu `tsconfig.json` (este projeto já está configurado dessa forma).
+
+## Dica de usabilidade
+
+Todos os gráficos expostos possuem tooltips e animações ativadas por padrão. Caso queira desabilitar algum comportamento, basta clonar o componente e ajustar a partir dos componentes base do `recharts`.
+
+Boas visualizações! 🎉

--- a/src/charts/SparklineTrendChart.tsx
+++ b/src/charts/SparklineTrendChart.tsx
@@ -1,0 +1,75 @@
+import { useId } from 'react';
+import type { CSSProperties } from 'react';
+import { Area, AreaChart, ResponsiveContainer, Tooltip } from 'recharts';
+
+export interface SparklinePoint {
+  label: string;
+  value: number;
+}
+
+export interface SparklineTrendChartProps {
+  data: SparklinePoint[];
+  title?: string;
+  caption?: string;
+  lineColor?: string;
+  areaColor?: string;
+}
+
+const tooltipStyles: CSSProperties = {
+  background: '#0f172a',
+  border: '1px solid rgba(148, 163, 184, 0.3)',
+  borderRadius: 12,
+  padding: '6px 10px',
+  color: '#f1f5f9',
+  boxShadow: '0 18px 45px rgba(15, 23, 42, 0.35)'
+};
+
+export function SparklineTrendChart({
+  data,
+  title,
+  caption,
+  lineColor = '#22d3ee',
+  areaColor
+}: SparklineTrendChartProps) {
+  const fillColor = areaColor ?? `${lineColor}33`;
+  const gradientId = `sparkline-${useId()}`;
+
+  return (
+    <section className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-aurora-end/20">
+      {(title || caption) && (
+        <header className="flex flex-wrap items-center gap-3">
+          {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}
+          {caption && (
+            <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/70">{caption}</span>
+          )}
+        </header>
+      )}
+      <div className="h-48 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data}>
+            <defs>
+              <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+                <stop offset="5%" stopColor={fillColor} stopOpacity={0.9} />
+                <stop offset="95%" stopColor={fillColor} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <Tooltip
+              contentStyle={tooltipStyles}
+              cursor={{ strokeDasharray: '4 8', strokeWidth: 2 }}
+              formatter={(value: number) => [value, 'Valor']}
+            />
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke={lineColor}
+              strokeWidth={3}
+              fill={`url(#${gradientId})`}
+              dot={{ r: 4, stroke: '#0f172a', strokeWidth: 2 }}
+              activeDot={{ r: 6 }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/charts/index.ts
+++ b/src/charts/index.ts
@@ -1,0 +1,6 @@
+export * from './InteractiveBarChart';
+export * from './MultiSeriesLineChart';
+export * from './DonutBreakdownChart';
+export * from './SparklineTrendChart';
+export * from './BarChart';
+export * from './TrendSparkline';


### PR DESCRIPTION
## Summary
- add reusable bar, line, donut, and sparkline chart components built with Recharts and configurable colors
- document usage examples and placement guidance in a new charts README
- expose all chart components through a single charts index for easy importing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5c1411068832e9a12ac78a40f56f5